### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-024c6dee-v1"
+              "version": "idf-release_v5.1-77a3025a-v1"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-024c6dee-v1",
+          "version": "idf-release_v5.1-77a3025a-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
-              "checksum": "SHA-256:d05626f6d13f1fdeecb6a72ab46c0ea2e53655e6c373d82a43a4ddbe8a7554a7",
-              "size": "306068927"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
+              "checksum": "SHA-256:4956820b7503c0dcf89f1e6d26481ffcd0268511f4645721cc4619728108f7ac",
+              "size": "306683337"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
-              "checksum": "SHA-256:d05626f6d13f1fdeecb6a72ab46c0ea2e53655e6c373d82a43a4ddbe8a7554a7",
-              "size": "306068927"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
+              "checksum": "SHA-256:4956820b7503c0dcf89f1e6d26481ffcd0268511f4645721cc4619728108f7ac",
+              "size": "306683337"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
-              "checksum": "SHA-256:d05626f6d13f1fdeecb6a72ab46c0ea2e53655e6c373d82a43a4ddbe8a7554a7",
-              "size": "306068927"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
+              "checksum": "SHA-256:4956820b7503c0dcf89f1e6d26481ffcd0268511f4645721cc4619728108f7ac",
+              "size": "306683337"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
-              "checksum": "SHA-256:d05626f6d13f1fdeecb6a72ab46c0ea2e53655e6c373d82a43a4ddbe8a7554a7",
-              "size": "306068927"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
+              "checksum": "SHA-256:4956820b7503c0dcf89f1e6d26481ffcd0268511f4645721cc4619728108f7ac",
+              "size": "306683337"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
-              "checksum": "SHA-256:d05626f6d13f1fdeecb6a72ab46c0ea2e53655e6c373d82a43a4ddbe8a7554a7",
-              "size": "306068927"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
+              "checksum": "SHA-256:4956820b7503c0dcf89f1e6d26481ffcd0268511f4645721cc4619728108f7ac",
+              "size": "306683337"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
-              "checksum": "SHA-256:d05626f6d13f1fdeecb6a72ab46c0ea2e53655e6c373d82a43a4ddbe8a7554a7",
-              "size": "306068927"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
+              "checksum": "SHA-256:4956820b7503c0dcf89f1e6d26481ffcd0268511f4645721cc4619728108f7ac",
+              "size": "306683337"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
-              "checksum": "SHA-256:d05626f6d13f1fdeecb6a72ab46c0ea2e53655e6c373d82a43a4ddbe8a7554a7",
-              "size": "306068927"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
+              "checksum": "SHA-256:4956820b7503c0dcf89f1e6d26481ffcd0268511f4645721cc4619728108f7ac",
+              "size": "306683337"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
-              "checksum": "SHA-256:d05626f6d13f1fdeecb6a72ab46c0ea2e53655e6c373d82a43a4ddbe8a7554a7",
-              "size": "306068927"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
+              "checksum": "SHA-256:4956820b7503c0dcf89f1e6d26481ffcd0268511f4645721cc4619728108f7ac",
+              "size": "306683337"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-9439479f"
+              "version": "idf-release_v5.1-64849cb7-v2"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-9439479f",
+          "version": "idf-release_v5.1-64849cb7-v2",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
+              "checksum": "SHA-256:b288450e6c5453b40407e22b3409bc964e7562635f454bbe3e5acda0ae93c3db",
+              "size": "306003472"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
+              "checksum": "SHA-256:b288450e6c5453b40407e22b3409bc964e7562635f454bbe3e5acda0ae93c3db",
+              "size": "306003472"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
+              "checksum": "SHA-256:b288450e6c5453b40407e22b3409bc964e7562635f454bbe3e5acda0ae93c3db",
+              "size": "306003472"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
+              "checksum": "SHA-256:b288450e6c5453b40407e22b3409bc964e7562635f454bbe3e5acda0ae93c3db",
+              "size": "306003472"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
+              "checksum": "SHA-256:b288450e6c5453b40407e22b3409bc964e7562635f454bbe3e5acda0ae93c3db",
+              "size": "306003472"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
+              "checksum": "SHA-256:b288450e6c5453b40407e22b3409bc964e7562635f454bbe3e5acda0ae93c3db",
+              "size": "306003472"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
+              "checksum": "SHA-256:b288450e6c5453b40407e22b3409bc964e7562635f454bbe3e5acda0ae93c3db",
+              "size": "306003472"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-9439479f.zip",
-              "checksum": "SHA-256:f9db39bdd827ff449691ac8913b3f459ee3e73353db853547b9ccc3906335a64",
-              "size": "305294843"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
+              "checksum": "SHA-256:b288450e6c5453b40407e22b3409bc964e7562635f454bbe3e5acda0ae93c3db",
+              "size": "306003472"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-64849cb7-v2"
+              "version": "idf-release_v5.1-024c6dee-v1"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-64849cb7-v2",
+          "version": "idf-release_v5.1-024c6dee-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
-              "checksum": "SHA-256:b288450e6c5453b40407e22b3409bc964e7562635f454bbe3e5acda0ae93c3db",
-              "size": "306003472"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
+              "checksum": "SHA-256:d05626f6d13f1fdeecb6a72ab46c0ea2e53655e6c373d82a43a4ddbe8a7554a7",
+              "size": "306068927"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
-              "checksum": "SHA-256:b288450e6c5453b40407e22b3409bc964e7562635f454bbe3e5acda0ae93c3db",
-              "size": "306003472"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
+              "checksum": "SHA-256:d05626f6d13f1fdeecb6a72ab46c0ea2e53655e6c373d82a43a4ddbe8a7554a7",
+              "size": "306068927"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
-              "checksum": "SHA-256:b288450e6c5453b40407e22b3409bc964e7562635f454bbe3e5acda0ae93c3db",
-              "size": "306003472"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
+              "checksum": "SHA-256:d05626f6d13f1fdeecb6a72ab46c0ea2e53655e6c373d82a43a4ddbe8a7554a7",
+              "size": "306068927"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
-              "checksum": "SHA-256:b288450e6c5453b40407e22b3409bc964e7562635f454bbe3e5acda0ae93c3db",
-              "size": "306003472"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
+              "checksum": "SHA-256:d05626f6d13f1fdeecb6a72ab46c0ea2e53655e6c373d82a43a4ddbe8a7554a7",
+              "size": "306068927"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
-              "checksum": "SHA-256:b288450e6c5453b40407e22b3409bc964e7562635f454bbe3e5acda0ae93c3db",
-              "size": "306003472"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
+              "checksum": "SHA-256:d05626f6d13f1fdeecb6a72ab46c0ea2e53655e6c373d82a43a4ddbe8a7554a7",
+              "size": "306068927"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
-              "checksum": "SHA-256:b288450e6c5453b40407e22b3409bc964e7562635f454bbe3e5acda0ae93c3db",
-              "size": "306003472"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
+              "checksum": "SHA-256:d05626f6d13f1fdeecb6a72ab46c0ea2e53655e6c373d82a43a4ddbe8a7554a7",
+              "size": "306068927"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
-              "checksum": "SHA-256:b288450e6c5453b40407e22b3409bc964e7562635f454bbe3e5acda0ae93c3db",
-              "size": "306003472"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
+              "checksum": "SHA-256:d05626f6d13f1fdeecb6a72ab46c0ea2e53655e6c373d82a43a4ddbe8a7554a7",
+              "size": "306068927"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-64849cb7-v2.zip",
-              "checksum": "SHA-256:b288450e6c5453b40407e22b3409bc964e7562635f454bbe3e5acda0ae93c3db",
-              "size": "306003472"
+              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-024c6dee-v1.zip",
+              "checksum": "SHA-256:d05626f6d13f1fdeecb6a72ab46c0ea2e53655e6c373d82a43a4ddbe8a7554a7",
+              "size": "306068927"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -111,56 +111,56 @@
               "host": "i686-mingw32",
               "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:fe5fd78588725e018ccbe37bdba21d58ba404a5da1ed7c52302d22e602c4641f",
+              "checksum": "SHA-256:f340e04d53bec53a2714397e2cd9e76b44c175f7def2a304f108eb1fad69d7ba",
               "size": "306428729"
             },
             {
               "host": "x86_64-mingw32",
               "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:fe5fd78588725e018ccbe37bdba21d58ba404a5da1ed7c52302d22e602c4641f",
+              "checksum": "SHA-256:f340e04d53bec53a2714397e2cd9e76b44c175f7def2a304f108eb1fad69d7ba",
               "size": "306428729"
             },
             {
               "host": "arm64-apple-darwin",
               "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:fe5fd78588725e018ccbe37bdba21d58ba404a5da1ed7c52302d22e602c4641f",
+              "checksum": "SHA-256:f340e04d53bec53a2714397e2cd9e76b44c175f7def2a304f108eb1fad69d7ba",
               "size": "306428729"
             },
             {
               "host": "x86_64-apple-darwin",
               "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:fe5fd78588725e018ccbe37bdba21d58ba404a5da1ed7c52302d22e602c4641f",
+              "checksum": "SHA-256:f340e04d53bec53a2714397e2cd9e76b44c175f7def2a304f108eb1fad69d7ba",
               "size": "306428729"
             },
             {
               "host": "x86_64-pc-linux-gnu",
               "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:fe5fd78588725e018ccbe37bdba21d58ba404a5da1ed7c52302d22e602c4641f",
+              "checksum": "SHA-256:f340e04d53bec53a2714397e2cd9e76b44c175f7def2a304f108eb1fad69d7ba",
               "size": "306428729"
             },
             {
               "host": "i686-pc-linux-gnu",
               "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:fe5fd78588725e018ccbe37bdba21d58ba404a5da1ed7c52302d22e602c4641f",
+              "checksum": "SHA-256:f340e04d53bec53a2714397e2cd9e76b44c175f7def2a304f108eb1fad69d7ba",
               "size": "306428729"
             },
             {
               "host": "aarch64-linux-gnu",
               "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:fe5fd78588725e018ccbe37bdba21d58ba404a5da1ed7c52302d22e602c4641f",
+              "checksum": "SHA-256:f340e04d53bec53a2714397e2cd9e76b44c175f7def2a304f108eb1fad69d7ba",
               "size": "306428729"
             },
             {
               "host": "arm-linux-gnueabihf",
               "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:fe5fd78588725e018ccbe37bdba21d58ba404a5da1ed7c52302d22e602c4641f",
+              "checksum": "SHA-256:f340e04d53bec53a2714397e2cd9e76b44c175f7def2a304f108eb1fad69d7ba",
               "size": "306428729"
             }
           ]

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-77a3025a-v1"
+              "version": "idf-release_v5.1-e12a1522-v1"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-77a3025a-v1",
+          "version": "idf-release_v5.1-e12a1522-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
-              "checksum": "SHA-256:4956820b7503c0dcf89f1e6d26481ffcd0268511f4645721cc4619728108f7ac",
-              "size": "306683337"
+              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
+              "checksum": "SHA-256:fe5fd78588725e018ccbe37bdba21d58ba404a5da1ed7c52302d22e602c4641f",
+              "size": "306428729"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
-              "checksum": "SHA-256:4956820b7503c0dcf89f1e6d26481ffcd0268511f4645721cc4619728108f7ac",
-              "size": "306683337"
+              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
+              "checksum": "SHA-256:fe5fd78588725e018ccbe37bdba21d58ba404a5da1ed7c52302d22e602c4641f",
+              "size": "306428729"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
-              "checksum": "SHA-256:4956820b7503c0dcf89f1e6d26481ffcd0268511f4645721cc4619728108f7ac",
-              "size": "306683337"
+              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
+              "checksum": "SHA-256:fe5fd78588725e018ccbe37bdba21d58ba404a5da1ed7c52302d22e602c4641f",
+              "size": "306428729"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
-              "checksum": "SHA-256:4956820b7503c0dcf89f1e6d26481ffcd0268511f4645721cc4619728108f7ac",
-              "size": "306683337"
+              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
+              "checksum": "SHA-256:fe5fd78588725e018ccbe37bdba21d58ba404a5da1ed7c52302d22e602c4641f",
+              "size": "306428729"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
-              "checksum": "SHA-256:4956820b7503c0dcf89f1e6d26481ffcd0268511f4645721cc4619728108f7ac",
-              "size": "306683337"
+              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
+              "checksum": "SHA-256:fe5fd78588725e018ccbe37bdba21d58ba404a5da1ed7c52302d22e602c4641f",
+              "size": "306428729"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
-              "checksum": "SHA-256:4956820b7503c0dcf89f1e6d26481ffcd0268511f4645721cc4619728108f7ac",
-              "size": "306683337"
+              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
+              "checksum": "SHA-256:fe5fd78588725e018ccbe37bdba21d58ba404a5da1ed7c52302d22e602c4641f",
+              "size": "306428729"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
-              "checksum": "SHA-256:4956820b7503c0dcf89f1e6d26481ffcd0268511f4645721cc4619728108f7ac",
-              "size": "306683337"
+              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
+              "checksum": "SHA-256:fe5fd78588725e018ccbe37bdba21d58ba404a5da1ed7c52302d22e602c4641f",
+              "size": "306428729"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-77a3025a-v1.zip",
-              "checksum": "SHA-256:4956820b7503c0dcf89f1e6d26481ffcd0268511f4645721cc4619728108f7ac",
-              "size": "306683337"
+              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
+              "checksum": "SHA-256:fe5fd78588725e018ccbe37bdba21d58ba404a5da1ed7c52302d22e602c4641f",
+              "size": "306428729"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -111,56 +111,56 @@
               "host": "i686-mingw32",
               "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:f340e04d53bec53a2714397e2cd9e76b44c175f7def2a304f108eb1fad69d7ba",
+              "checksum": "SHA-256:04e2fef64d3f2606b9dc77259a25c3fc8a4a17611c859c4bb992f7672d05ff30",
               "size": "306428729"
             },
             {
               "host": "x86_64-mingw32",
               "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:f340e04d53bec53a2714397e2cd9e76b44c175f7def2a304f108eb1fad69d7ba",
+              "checksum": "SHA-256:04e2fef64d3f2606b9dc77259a25c3fc8a4a17611c859c4bb992f7672d05ff30",
               "size": "306428729"
             },
             {
               "host": "arm64-apple-darwin",
               "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:f340e04d53bec53a2714397e2cd9e76b44c175f7def2a304f108eb1fad69d7ba",
+              "checksum": "SHA-256:04e2fef64d3f2606b9dc77259a25c3fc8a4a17611c859c4bb992f7672d05ff30",
               "size": "306428729"
             },
             {
               "host": "x86_64-apple-darwin",
               "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:f340e04d53bec53a2714397e2cd9e76b44c175f7def2a304f108eb1fad69d7ba",
+              "checksum": "SHA-256:04e2fef64d3f2606b9dc77259a25c3fc8a4a17611c859c4bb992f7672d05ff30",
               "size": "306428729"
             },
             {
               "host": "x86_64-pc-linux-gnu",
               "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:f340e04d53bec53a2714397e2cd9e76b44c175f7def2a304f108eb1fad69d7ba",
+              "checksum": "SHA-256:04e2fef64d3f2606b9dc77259a25c3fc8a4a17611c859c4bb992f7672d05ff30",
               "size": "306428729"
             },
             {
               "host": "i686-pc-linux-gnu",
               "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:f340e04d53bec53a2714397e2cd9e76b44c175f7def2a304f108eb1fad69d7ba",
+              "checksum": "SHA-256:04e2fef64d3f2606b9dc77259a25c3fc8a4a17611c859c4bb992f7672d05ff30",
               "size": "306428729"
             },
             {
               "host": "aarch64-linux-gnu",
               "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:f340e04d53bec53a2714397e2cd9e76b44c175f7def2a304f108eb1fad69d7ba",
+              "checksum": "SHA-256:04e2fef64d3f2606b9dc77259a25c3fc8a4a17611c859c4bb992f7672d05ff30",
               "size": "306428729"
             },
             {
               "host": "arm-linux-gnueabihf",
               "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:f340e04d53bec53a2714397e2cd9e76b44c175f7def2a304f108eb1fad69d7ba",
+              "checksum": "SHA-256:04e2fef64d3f2606b9dc77259a25c3fc8a4a17611c859c4bb992f7672d05ff30",
               "size": "306428729"
             }
           ]


### PR DESCRIPTION
```
lib-builder: release/v5.1 8a016b4
esp-idf: release/v5.1 e12a1522e8
arduino: idf-release/v5.1 467935f0
tinyusb: master 310b8657f
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.4.12
espressif__esp-modbus: 1.0.16
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-sr: 1.9.4
espressif__esp-tflite-micro: 1.3.2
espressif__esp-zboss-lib: 1.6.0
espressif__esp-zigbee-lib: 1.6.0
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_insights: 1.2.2
espressif__esp_modem: 1.2.1
espressif__esp_rainmaker: 1.5.1
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.4.2
espressif__network_provisioning: 1.0.3
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
espressif__esp-dsp: 1.5.2
```
