### PR TITLE
IDF release/v5.1

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.1-e12a1522-v1"
+              "version": "idf-release_v5.1-e12a1522-v2"
             },
             {
               "packager": "esp32",
@@ -105,63 +105,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.1-e12a1522-v1",
+          "version": "idf-release_v5.1-e12a1522-v2",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:04e2fef64d3f2606b9dc77259a25c3fc8a4a17611c859c4bb992f7672d05ff30",
-              "size": "306428729"
+              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v2.zip",
+              "checksum": "SHA-256:cd439e136d2fa77fcc45bf4eb4bacd6cfc6efc64d7634121de5b15dfdedb5ee1",
+              "size": "306429102"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:04e2fef64d3f2606b9dc77259a25c3fc8a4a17611c859c4bb992f7672d05ff30",
-              "size": "306428729"
+              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v2.zip",
+              "checksum": "SHA-256:cd439e136d2fa77fcc45bf4eb4bacd6cfc6efc64d7634121de5b15dfdedb5ee1",
+              "size": "306429102"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:04e2fef64d3f2606b9dc77259a25c3fc8a4a17611c859c4bb992f7672d05ff30",
-              "size": "306428729"
+              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v2.zip",
+              "checksum": "SHA-256:cd439e136d2fa77fcc45bf4eb4bacd6cfc6efc64d7634121de5b15dfdedb5ee1",
+              "size": "306429102"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:04e2fef64d3f2606b9dc77259a25c3fc8a4a17611c859c4bb992f7672d05ff30",
-              "size": "306428729"
+              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v2.zip",
+              "checksum": "SHA-256:cd439e136d2fa77fcc45bf4eb4bacd6cfc6efc64d7634121de5b15dfdedb5ee1",
+              "size": "306429102"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:04e2fef64d3f2606b9dc77259a25c3fc8a4a17611c859c4bb992f7672d05ff30",
-              "size": "306428729"
+              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v2.zip",
+              "checksum": "SHA-256:cd439e136d2fa77fcc45bf4eb4bacd6cfc6efc64d7634121de5b15dfdedb5ee1",
+              "size": "306429102"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:04e2fef64d3f2606b9dc77259a25c3fc8a4a17611c859c4bb992f7672d05ff30",
-              "size": "306428729"
+              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v2.zip",
+              "checksum": "SHA-256:cd439e136d2fa77fcc45bf4eb4bacd6cfc6efc64d7634121de5b15dfdedb5ee1",
+              "size": "306429102"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:04e2fef64d3f2606b9dc77259a25c3fc8a4a17611c859c4bb992f7672d05ff30",
-              "size": "306428729"
+              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v2.zip",
+              "checksum": "SHA-256:cd439e136d2fa77fcc45bf4eb4bacd6cfc6efc64d7634121de5b15dfdedb5ee1",
+              "size": "306429102"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v1.zip",
-              "checksum": "SHA-256:04e2fef64d3f2606b9dc77259a25c3fc8a4a17611c859c4bb992f7672d05ff30",
-              "size": "306428729"
+              "url": "https://github.com/darkxst/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-e12a1522-v2.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.1-e12a1522-v2.zip",
+              "checksum": "SHA-256:cd439e136d2fa77fcc45bf4eb4bacd6cfc6efc64d7634121de5b15dfdedb5ee1",
+              "size": "306429102"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: release/v5.1 8a016b4
esp-idf: release/v5.1 e12a1522e8
arduino: idf-release/v5.1 fcfc936a
tinyusb: master cb22301f9
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dl:
espressif__esp-dsp: 1.4.12
espressif__esp-modbus: 1.0.16
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-sr: 1.9.4
espressif__esp-tflite-micro: 1.3.2
espressif__esp-zboss-lib: 1.6.0
espressif__esp-zigbee-lib: 1.6.0
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.2
espressif__esp_diagnostics: 1.2.1
espressif__esp_insights: 1.2.2
espressif__esp_modem: 1.2.1
espressif__esp_rainmaker: 1.5.1
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.4.2
espressif__network_provisioning: 1.0.3
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.14.8
espressif__esp-dsp: 1.5.2
```
